### PR TITLE
Fix "/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run: line 200: necho: command not found"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM linuxserver/wireguard:1.0.20210914
 
 # Normally with docker, you would set these sysctls via the run command, but fly.io isn't really docker
-RUN echo '\n\
-echo "Writing sysctl settings" \n\
-sysctl -w net.ipv4.conf.all.src_valid_mark=1 \n\
-sysctl -w net.ipv4.ip_forward=1' >> /etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+RUN cat <<EOF >> /etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+echo "Writing sysctl settings"
+sysctl -w net.ipv4.conf.all.src_valid_mark=1
+sysctl -w net.ipv4.ip_forward=1
+EOF
 
 # Addresses issue with s6-overlay wanting to run as pid 1
 # For more info see https://github.com/pi-hole/docker-pi-hole/issues/1176#issuecomment-1232363970


### PR DESCRIPTION
The container was failing to start due to a 'necho: command not found' error in /etc/s6-overlay/s6-rc.d/init-wireguard-confs/run. This was caused by `echo` in the Dockerfile not escaping newlines properly.

Replaced the escaped multiline echo with a heredoc to prevent the issue and improve readability.